### PR TITLE
Add support for each API method definition to define middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ function createUser(username, password, name) {
     // ...
 }
 
-function middlewareFn(ctx, auth) {
+function middlewareFn(ctx, next) {
     // ...
 }
 
@@ -170,7 +170,7 @@ The following properties can be set:
 |`args[idx].validate`   | No        | A function that will be executed on the successfully parsed/coerced input value. Should not modify or return a value, should throw if invalid.    |
 |`args[idx].optional`   | No        | A boolean indicating whether the argument is optional. Defaults to `false`. If user fails to provide a required arguments, the request will fail.         |
 |`args[idx].default`    | No        | A primitive type or object. If user fails to provide an optional argument, the default will be provided.         |
-|`middleware`           | No        | An array of functions to run as middleware. Accepts request context and auth context as params. Throw on error to abort request handler |
+|`middleware`           | No        | An array of functions to run as middleware. Accepts request context and callback function as params. Throw on error to abort request handler |
 
 ## Runtime errors
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ function createUser(username, password, name) {
     // ...
 }
 
+function middlewareFn(ctx, auth) {
+    // ...
+}
+
 const model = swatch({
     "users.create": {
         handler: createUser,
@@ -144,6 +148,7 @@ const model = swatch({
                 default: 'New User',
             },
         ],
+        middleware: [middlewareFn],
     },
 });
 ```
@@ -164,7 +169,8 @@ The following properties can be set:
 |`args[idx].parse`      | No        | A function that will be executed on the input. Can be used to perform type coercions. If present, should return desired value, or throw.    |
 |`args[idx].validate`   | No        | A function that will be executed on the successfully parsed/coerced input value. Should not modify or return a value, should throw if invalid.    |
 |`args[idx].optional`   | No        | A boolean indicating whether the argument is optional. Defaults to `false`. If user fails to provide a required arguments, the request will fail.         |
-|`args[idx].optional`   | No        | A primitive type or object. If user fails to provide an optional argument, the default will be provided.         |
+|`args[idx].default`    | No        | A primitive type or object. If user fails to provide an optional argument, the default will be provided.         |
+|`middleware`           | No        | An array of functions to run as middleware. Accepts request context and auth context as params. Throw on error to abort request handler |
 
 ## Runtime errors
 
@@ -213,6 +219,7 @@ Each object will contain the following properties:
 |:---                   |:---                                                                       |
 |`name`                 | The name of the method. This is the same as the key in the API object.    |
 |`handle`               | A function used to execute the method handler. See [The `handle` function](#the-handle-function) below.   |
+|`middleware`           | An array of functions to execute as middleware before the method handler. |
 
 ### The `handle` function
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -15,6 +15,7 @@ function load(api) {
     return {
       name: key,
       handle: handler(methodSchema),
+      middleware: methodSchema.middleware || [],
     };
   }
 }

--- a/lib/schemas/service.js
+++ b/lib/schemas/service.js
@@ -27,12 +27,18 @@ const args =
     .array()
     .items(argName, argObject);
 
+const middleware =
+  Joi
+    .array()
+    .items(Joi.func());
+
 const method = [
   Joi
     .object()
     .keys({
       handler: handler,
       args: args,
+      middleware: middleware,
     })
     .requiredKeys('handler'),
   Joi.func(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Framework for easily creating and exposing APIs as methods",
   "main": "lib/index.js",
   "scripts": {

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -78,7 +78,7 @@ describe('model', () => {
         "noop": {
           handler: (a, b) => {},
           args: ['a', 'b'],
-          middleware: [1, (ctx, auth) => {}],
+          middleware: [1, (ctx, next) => {}],
         }
       };
       expect(() => load(api)).to.throw();
@@ -158,8 +158,8 @@ describe('model', () => {
     it('should pass in middleware array', () => {
       const add = (a, b) => a + b;
       const middleware = [
-        (ctx, auth) => { return ctx },
-        (ctx, auth) => { return auth }
+        (ctx, next) => { return ctx },
+        (ctx, next) => { return next + 1 },
       ];
       const api = {
         "numbers.add": {
@@ -183,7 +183,7 @@ describe('model', () => {
 
       expect(model[0].middleware).to.be.an('array').that.has.lengthOf(2);
       expect(model[0].middleware[0](1, 2)).to.equal(1);
-      expect(model[0].middleware[1](1, 2)).to.equal(2);
+      expect(model[0].middleware[1](1, 2)).to.equal(3);
     });
   });
 });

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -5,9 +5,10 @@ const load = require('../lib/loader');
 
 function validate(model) {
   model.forEach(method => {
-    expect(method).to.be.an('object').that.has.all.keys('name', 'handle');
+    expect(method).to.be.an('object').that.has.all.keys('name', 'handle', 'middleware');
     expect(method.name).to.be.a('string');
     expect(method.handle).to.be.a('function');
+    expect(method.middleware).to.be.an('array');
   });
 }
 
@@ -71,6 +72,17 @@ describe('model', () => {
       };
       expect(() => load(api)).to.throw();
     });
+
+    it('should reject if middleware is not a list of functions', () => {
+      const api = {
+        "noop": {
+          handler: (a, b) => {},
+          args: ['a', 'b'],
+          middleware: [1, (ctx, auth) => {}],
+        }
+      };
+      expect(() => load(api)).to.throw();
+    });
   });
 
   describe('results', () => {
@@ -86,6 +98,7 @@ describe('model', () => {
       const model = load(api);
       expect(model).to.be.an('array').that.has.lengthOf(1);
       validate(model);
+      expect(model[0].middleware).to.be.an('array').that.has.lengthOf(0);
     });
 
     it('should accept an endpoint with only named arguments', () => {
@@ -99,6 +112,7 @@ describe('model', () => {
       const model = load(api);
       expect(model).to.be.an('array').that.has.lengthOf(1);
       validate(model);
+      expect(model[0].middleware).to.be.an('array').that.has.lengthOf(0);
     });
 
     it('should accept an endpoint with an unnamed argument array', () => {
@@ -115,6 +129,7 @@ describe('model', () => {
       const model = load(api);
       expect(model).to.be.an('array').that.has.lengthOf(1);
       validate(model);
+      expect(model[0].middleware).to.be.an('array').that.has.lengthOf(0);
     });
 
     it('should produce an endpoint metadata array', () => {
@@ -137,6 +152,38 @@ describe('model', () => {
       const model = load(api);
       expect(model).to.be.an('array').that.has.lengthOf(1);
       validate(model);
+      expect(model[0].middleware).to.be.an('array').that.has.lengthOf(0);
+    });
+
+    it('should pass in middleware array', () => {
+      const add = (a, b) => a + b;
+      const middleware = [
+        (ctx, auth) => { return ctx },
+        (ctx, auth) => { return auth }
+      ];
+      const api = {
+        "numbers.add": {
+          handler: add,
+          args: [
+            {
+              name: 'a',
+              parse: Number,
+            },
+            {
+              name: 'b',
+              parse: Number,
+            },
+          ],
+          middleware: middleware,
+        }
+      };
+      const model = load(api);
+      expect(model).to.be.an('array').that.has.lengthOf(1);
+      validate(model);
+
+      expect(model[0].middleware).to.be.an('array').that.has.lengthOf(2);
+      expect(model[0].middleware[0](1, 2)).to.equal(1);
+      expect(model[0].middleware[1](1, 2)).to.equal(2);
     });
   });
 });

--- a/test/schemas/validator.test.js
+++ b/test/schemas/validator.test.js
@@ -34,9 +34,9 @@ describe('validator', () => {
             },
           ],
           middleware: [
-            (ctx, auth) => { ctx },
-            (ctx, auth) => { auth },
-            (ctx, auth) => { true },
+            (ctx, next) => { ctx },
+            (ctx, next) => { next },
+            (ctx, next) => { true },
           ],
         },
       };
@@ -219,7 +219,7 @@ describe('validator', () => {
       const functionMiddlewareHandler = {
         fn: {
           handler: (arg_1) => { arg_1 },
-          middleware: (ctx) => { ctx },
+          middleware: (ctx, next) => { ctx },
         },
       };
       expect(() => validate(functionMiddlewareHandler)).to.throw();
@@ -235,7 +235,7 @@ describe('validator', () => {
       const mixedArrayMiddlewareHandler = {
         fn: {
           handler: (arg_1) => { arg_1 },
-          middleware: [1, true, (ctx, auth) => { auth }, (ctx, auth) => { ctx }],
+          middleware: [1, true, (ctx, next) => { ctx }, (ctx, next) => { ctx }],
         },
       };
       expect(() => validate(mixedArrayMiddlewareHandler)).to.throw();

--- a/test/schemas/validator.test.js
+++ b/test/schemas/validator.test.js
@@ -33,6 +33,11 @@ describe('validator', () => {
               default: 12,
             },
           ],
+          middleware: [
+            (ctx, auth) => { ctx },
+            (ctx, auth) => { auth },
+            (ctx, auth) => { true },
+          ],
         },
       };
       const validatedApi = validate(api);
@@ -200,6 +205,40 @@ describe('validator', () => {
         },
       };
       expect(() => validate(invalidOptionalParam)).to.throw();
+    });
+
+    it('should throw on invalid middleware definition', () => {
+      const numberMiddlewareHandler = {
+        fn: {
+          handler: (arg_1) => { arg_1 },
+          middleware: 100,
+        },
+      };
+      expect(() => validate(numberMiddlewareHandler)).to.throw();
+
+      const functionMiddlewareHandler = {
+        fn: {
+          handler: (arg_1) => { arg_1 },
+          middleware: (ctx) => { ctx },
+        },
+      };
+      expect(() => validate(functionMiddlewareHandler)).to.throw();
+
+      const numArrayMiddlewareHandler = {
+        fn: {
+          handler: (arg_1) => { arg_1 },
+          middleware: [1, 2, 3, 4, 5],
+        },
+      };
+      expect(() => validate(numArrayMiddlewareHandler)).to.throw();
+
+      const mixedArrayMiddlewareHandler = {
+        fn: {
+          handler: (arg_1) => { arg_1 },
+          middleware: [1, true, (ctx, auth) => { auth }, (ctx, auth) => { ctx }],
+        },
+      };
+      expect(() => validate(mixedArrayMiddlewareHandler)).to.throw();
     });
   });
 });


### PR DESCRIPTION
Add support for middleware, a custom list of functions for each API method
Middleware should be a list of functions, which take in the 'request ctx' and an 'auth ctx'
Each middleware fn should throw on error to break the chain and abort the request handler

Im open to discussing what these params should be... My initial intuition is that we should include the request ctx from the server framework, plus the auth ctx that is generated by the custom authAdapter. Clients can write their own authAdapter for swatchjs-koa/express which will analyze the request, grab auth info from wherever they choose (headers, etc), return an auth ctx of their choosing, which we can then pass to their middleware.

Idea being that, instead of making everyone write their request handlers to take in an (auth) param as an argument along with whatever else is defined in their 'args' array, use the middleware array to write any method-specific authentication checks and abort if necessary, so the handler functions themselves can simply run the logic.