### PR TITLE
Validation of Default Parameter

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const ERRORS = {
+  INVALID_DEFAULT:  'invalid_default',
   INVALID_ARG_LIST: 'invalid_arg_list',
   INVALID_ARG_NAME: 'invalid_arg_name',
   MISSING_ARG:      'missing_arg',

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -55,6 +55,16 @@ function getMatchFn(methodSchema) {
       //  `arg.name` is optional, so use name from method handler
       //  All the rest of the metadata should come from the schema
       const name = arg.name || functionArgs[idx];
+
+      // Make sure the default value passes validation
+      if (arg.validate !== void 0 && arg.default !== void 0) {
+        try {
+          arg.validate(arg.default);
+        } catch (err) {
+          throw errors.INVALID_DEFAULT;
+        }
+      }
+
       return {
         name,
         default: arg.default,

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -20,6 +20,62 @@ describe('handler', () => {
       };
       expect(() => handler(zeroMethod)).to.throw('invalid_arg_list');
     });
+
+    describe('defaults', () => {
+      it('should throw if arg.default and arg.validate are specified and the default does not validate', () => {
+        const oneFn = (a) => {};
+        const oneMethod = {
+          handler: oneFn,
+          args: [{
+            name: 'a',
+            parse: Number,
+            validate: (param) => { if (param === 0) throw new Error('validator puked on purpose') },
+            default: 0,
+          },],
+        };
+        expect(() => handler(oneMethod)).to.throw('invalid_default');
+      });
+
+      it('should not throw if the default does validate', () => {
+        const oneFn = (a) => {};
+        const oneMethod = {
+          handler: oneFn,
+          args: [{
+            name: 'a',
+            parse: Number,
+            validate: (param) => { if (param !== 0) throw new Error('validator puked on purpose') },
+            default: 0,
+          },],
+        };
+        expect(() => handler(oneMethod)).not.to.throw('invalid_default');
+      });
+
+      it('should not throw if arg.default is not specified', () => {
+        const oneFn = (a) => {};
+        const oneMethod = {
+          handler: oneFn,
+          args: [{
+            name: 'a',
+            parse: Number,
+            validate: (param) => { if (param === 0) throw new Error('validator puked on purpose') },
+          },],
+        };
+        expect(() => handler(oneMethod)).not.to.throw('invalid_default');
+      });
+
+      it('should not throw if arg.validate is not specified', () => {
+        const oneFn = (a) => {};
+        const oneMethod = {
+          handler: oneFn,
+          args: [{
+            name: 'a',
+            parse: Number,
+            default: 0,
+          },],
+        };
+        expect(() => handler(oneMethod)).not.to.throw('invalid_default');
+      });
+    });
   });
 
   describe('call time (args options explictly passed with names)', () => {


### PR DESCRIPTION
Prior to this PR, the validation function, if present, was applied to the parsedValue, and if no value was passed, the default was used. This means that if the validation function passed did not permit the default value passed, the author of the code would never know. The problem would only manifest itself to callers to the service. That's bad, so with this PR we will now validate the default value at initialization.