### PR TITLE
Fix Circle CI Circular Builds: Do Not Build Tagged Commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,9 +43,19 @@ jobs:
               git config --global user.email "npm@builtforme.tech"
               git config --global user.name "Built For Me Automated Publisher"
               npm version patch
-              git push
+              git push --follow-tags
               echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
               npm publish --access public
             else
               echo "Not publishing to npm because branch is not master."
             fi
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build:
+        filters:
+          tags:
+            # Do not build tagged commits, since they were created by a previous build
+            ignore: /v[0-9]+(\.[0-9]+)*/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "0.1.5",
+  "version": "0.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Framework for easily creating and exposing APIs as methods",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Since when CircleCI runs it runs `npm version patch` to version package.json then commits it back to GitHub, we don't want that commit back to GitHub to trigger another build.