### PR TITLE
Swatch supports a user-defined metadata blob in schema definitions

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -7,15 +7,11 @@ const validate = validator(serviceSchema);
 function load(api) {
   function prepare(key) {
     const methodSchema = api[key];
-    const metadata = methodSchema.metadata || {};
 
     return {
       name: key,
       handle: handler(methodSchema),
-      metadata: {
-        noAuth: metadata.noAuth || false,
-        middleware: metadata.middleware || [],
-      },
+      metadata: methodSchema.metadata || {},
     };
   }
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -7,12 +7,15 @@ const validate = validator(serviceSchema);
 function load(api) {
   function prepare(key) {
     const methodSchema = api[key];
+    const metadata = methodSchema.metadata || {};
 
     return {
       name: key,
       handle: handler(methodSchema),
-      noAuth: methodSchema.noAuth || false,
-      middleware: methodSchema.middleware || [],
+      metadata: {
+        noAuth: metadata.noAuth || false,
+        middleware: metadata.middleware || [],
+      },
     };
   }
 

--- a/lib/schemas/service.js
+++ b/lib/schemas/service.js
@@ -34,14 +34,21 @@ const noAuth =
   Joi
     .boolean();
 
+const metadata =
+  Joi
+    .object()
+    .keys({
+      noAuth,
+      middleware,
+    });
+
 const method = [
   Joi
     .object()
     .keys({
       handler,
       args,
-      noAuth,
-      middleware,
+      metadata,
     })
     .requiredKeys('handler'),
   Joi.func(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "0.1.38",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "0.1.38",
+  "version": "0.2.0",
   "description": "Framework for easily creating and exposing APIs as methods",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "description": "Framework for easily creating and exposing APIs as methods",
   "main": "lib/index.js",
   "scripts": {

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -3,11 +3,13 @@ const load = require('../lib/loader');
 
 function validate(model) {
   model.forEach((method) => {
-    expect(method).to.be.an('object').that.has.all.keys('name', 'handle', 'middleware', 'noAuth');
+    expect(method).to.be.an('object').that.has.all.keys('name', 'handle', 'metadata');
     expect(method.name).to.be.a('string');
     expect(method.handle).to.be.a('function');
-    expect(method.middleware).to.be.an('array');
-    expect(method.noAuth).to.be.an('boolean');
+
+    expect(method.metadata).to.be.an('object').that.has.all.keys('noAuth', 'middleware');
+    expect(method.metadata.noAuth).to.be.an('boolean');
+    expect(method.metadata.middleware).to.be.an('array');
   });
 }
 
@@ -72,12 +74,38 @@ describe('model', () => {
       expect(() => load(api)).to.throw();
     });
 
+    it('should reject if metadata is not an object', () => {
+      const api = {
+        noop: {
+          handler: (a, b) => (a + b),
+          args: ['a', 'b'],
+          metadata: () => {},
+        },
+      };
+      expect(() => load(api)).to.throw();
+    });
+
     it('should reject if middleware is not a list of functions', () => {
       const api = {
         noop: {
           handler: (a, b) => (a + b),
           args: ['a', 'b'],
-          middleware: [1, () => {}],
+          metadata: {
+            middleware: [1, () => {}],
+          },
+        },
+      };
+      expect(() => load(api)).to.throw();
+    });
+
+    it('should reject if noAuth is not a boolean', () => {
+      const api = {
+        noop: {
+          handler: (a, b) => (a + b),
+          args: ['a', 'b'],
+          metadata: {
+            noAuth: 0,
+          },
         },
       };
       expect(() => load(api)).to.throw();
@@ -98,7 +126,7 @@ describe('model', () => {
       const model = load(api);
       expect(model).to.be.an('array').that.has.lengthOf(1);
       validate(model);
-      expect(model[0].middleware).to.be.an('array').that.has.lengthOf(0);
+      expect(model[0].metadata.middleware).to.be.an('array').that.has.lengthOf(0);
     });
 
     it('should accept an endpoint with only named arguments', () => {
@@ -112,7 +140,7 @@ describe('model', () => {
       const model = load(api);
       expect(model).to.be.an('array').that.has.lengthOf(1);
       validate(model);
-      expect(model[0].middleware).to.be.an('array').that.has.lengthOf(0);
+      expect(model[0].metadata.middleware).to.be.an('array').that.has.lengthOf(0);
     });
 
     it('should accept an endpoint with an unnamed argument array', () => {
@@ -129,7 +157,7 @@ describe('model', () => {
       const model = load(api);
       expect(model).to.be.an('array').that.has.lengthOf(1);
       validate(model);
-      expect(model[0].middleware).to.be.an('array').that.has.lengthOf(0);
+      expect(model[0].metadata.middleware).to.be.an('array').that.has.lengthOf(0);
     });
 
     it('should produce an endpoint metadata array', () => {
@@ -152,7 +180,7 @@ describe('model', () => {
       const model = load(api);
       expect(model).to.be.an('array').that.has.lengthOf(1);
       validate(model);
-      expect(model[0].middleware).to.be.an('array').that.has.lengthOf(0);
+      expect(model[0].metadata.middleware).to.be.an('array').that.has.lengthOf(0);
     });
 
     it('should pass in middleware array', () => {
@@ -174,16 +202,18 @@ describe('model', () => {
               parse: Number,
             },
           ],
-          middleware,
+          metadata: {
+            middleware,
+          },
         },
       };
       const model = load(api);
       expect(model).to.be.an('array').that.has.lengthOf(1);
       validate(model);
 
-      expect(model[0].middleware).to.be.an('array').that.has.lengthOf(2);
-      expect(model[0].middleware[0](1, 2)).to.equal(1);
-      expect(model[0].middleware[1](1, 2)).to.equal(3);
+      expect(model[0].metadata.middleware).to.be.an('array').that.has.lengthOf(2);
+      expect(model[0].metadata.middleware[0](1, 2)).to.equal(1);
+      expect(model[0].metadata.middleware[1](1, 2)).to.equal(3);
     });
   });
 });

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -6,10 +6,7 @@ function validate(model) {
     expect(method).to.be.an('object').that.has.all.keys('name', 'handle', 'metadata');
     expect(method.name).to.be.a('string');
     expect(method.handle).to.be.a('function');
-
-    expect(method.metadata).to.be.an('object').that.has.all.keys('noAuth', 'middleware');
-    expect(method.metadata.noAuth).to.be.an('boolean');
-    expect(method.metadata.middleware).to.be.an('array');
+    expect(method.metadata).to.be.an('object');
   });
 }
 
@@ -126,7 +123,6 @@ describe('model', () => {
       const model = load(api);
       expect(model).to.be.an('array').that.has.lengthOf(1);
       validate(model);
-      expect(model[0].metadata.middleware).to.be.an('array').that.has.lengthOf(0);
     });
 
     it('should accept an endpoint with only named arguments', () => {
@@ -140,7 +136,6 @@ describe('model', () => {
       const model = load(api);
       expect(model).to.be.an('array').that.has.lengthOf(1);
       validate(model);
-      expect(model[0].metadata.middleware).to.be.an('array').that.has.lengthOf(0);
     });
 
     it('should accept an endpoint with an unnamed argument array', () => {
@@ -157,7 +152,6 @@ describe('model', () => {
       const model = load(api);
       expect(model).to.be.an('array').that.has.lengthOf(1);
       validate(model);
-      expect(model[0].metadata.middleware).to.be.an('array').that.has.lengthOf(0);
     });
 
     it('should produce an endpoint metadata array', () => {
@@ -180,7 +174,6 @@ describe('model', () => {
       const model = load(api);
       expect(model).to.be.an('array').that.has.lengthOf(1);
       validate(model);
-      expect(model[0].metadata.middleware).to.be.an('array').that.has.lengthOf(0);
     });
 
     it('should pass in middleware array', () => {

--- a/test/schemas/validator.test.js
+++ b/test/schemas/validator.test.js
@@ -31,12 +31,14 @@ describe('validator', () => {
               default: 12,
             },
           ],
-          middleware: [
-            ctx => (ctx),
-            () => {},
-            () => (true),
-          ],
-          noAuth: true,
+          metadata: {
+            middleware: [
+              ctx => (ctx),
+              () => {},
+              () => (true),
+            ],
+            noAuth: true,
+          },
         },
       };
       const validatedApi = validate(api);
@@ -121,7 +123,9 @@ describe('validator', () => {
       const nonBoolAuthParam = {
         fn: {
           handler: 100,
-          noAuth: 10000,
+          metadata: {
+            noAuth: 10000,
+          },
         },
       };
       expect(() => validate(nonBoolAuthParam)).to.throw();
@@ -129,7 +133,9 @@ describe('validator', () => {
       const functionAuthParam = {
         fn: {
           handler: 100,
-          noAuth: () => (true),
+          metadata: {
+            noAuth: () => (true),
+          },
         },
       };
       expect(() => validate(functionAuthParam)).to.throw();
@@ -224,11 +230,23 @@ describe('validator', () => {
       expect(() => validate(invalidOptionalParam)).to.throw();
     });
 
+    it('should throw on invalid metadata definition', () => {
+      const invalidMetadataHandler = {
+        fn: {
+          handler: arg1 => (arg1),
+          metadata: () => {},
+        },
+      };
+      expect(() => validate(invalidMetadataHandler)).to.throw();
+    });
+
     it('should throw on invalid middleware definition', () => {
       const numberMiddlewareHandler = {
         fn: {
           handler: arg1 => (arg1),
-          middleware: 100,
+          metadata: {
+            middleware: 100,
+          },
         },
       };
       expect(() => validate(numberMiddlewareHandler)).to.throw();
@@ -236,7 +254,9 @@ describe('validator', () => {
       const functionMiddlewareHandler = {
         fn: {
           handler: arg1 => (arg1),
-          middleware: () => {},
+          metadata: {
+            middleware: () => {},
+          },
         },
       };
       expect(() => validate(functionMiddlewareHandler)).to.throw();
@@ -244,7 +264,9 @@ describe('validator', () => {
       const numArrayMiddlewareHandler = {
         fn: {
           handler: arg1 => (arg1),
-          middleware: [1, 2, 3, 4, 5],
+          metadata: {
+            middleware: [1, 2, 3, 4, 5],
+          },
         },
       };
       expect(() => validate(numArrayMiddlewareHandler)).to.throw();
@@ -252,7 +274,9 @@ describe('validator', () => {
       const mixedArrayMiddlewareHandler = {
         fn: {
           handler: arg1 => (arg1),
-          middleware: [1, true, () => {}, () => {}],
+          metadata: {
+            middleware: [1, true, () => {}, () => {}],
+          },
         },
       };
       expect(() => validate(mixedArrayMiddlewareHandler)).to.throw();


### PR DESCRIPTION
Replace the known properties in swatch definition with a metadata argument that can contain user-defined properties that will be passed through to the swatch-* framework.