### PR TITLE
Create split methods for parsing params vs executing handers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
         "ecmaFeatures": {}
     },
     "rules": {
-      "no-throw-literal": "off"
+        "no-throw-literal": "off",
+        "no-param-reassign": ["error", { "props": false }]
     }
 }

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -113,12 +113,20 @@ function handler(methodSchema) {
   const normalizedSchema = normalize(methodSchema);
   const match = getMatchFn(normalizedSchema);
 
-  function handleMethod(params) {
+  function matchParams(koaCtx, params) {
     const args = match(params);
+    koaCtx.swatchCtx.args = args;
+  }
+
+  function handleMethod(koaCtx) {
+    const args = koaCtx.swatchCtx.args;
     return normalizedSchema.handler.apply(null, args);
   }
 
-  return handleMethod;
+  return {
+    match: matchParams,
+    handle: handleMethod,
+  };
 }
 
 module.exports = handler;

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -113,19 +113,19 @@ function handler(methodSchema) {
   const normalizedSchema = normalize(methodSchema);
   const match = getMatchFn(normalizedSchema);
 
-  function matchParams(koaCtx, params) {
+  function validateParams(ctx, params) {
     const args = match(params);
-    koaCtx.swatchCtx.args = args;
+    ctx.swatchCtx.args = args;
   }
 
-  function handleMethod(koaCtx) {
-    const args = koaCtx.swatchCtx.args;
+  function handleMethod(ctx) {
+    const args = ctx.swatchCtx.args;
     return normalizedSchema.handler.apply(null, args);
   }
 
   return {
-    match: matchParams,
     handle: handleMethod,
+    validate: validateParams,
   };
 }
 

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -103,7 +103,15 @@ function getMatchFn(methodSchema) {
       return parsedArg;
     });
 
-    return values;
+    const params = {};
+    expectedArgNames.forEach((name, idx) => {
+      params[name] = values[idx];
+    });
+
+    return {
+      values,
+      params,
+    };
   }
 
   return matcher;
@@ -114,12 +122,13 @@ function handler(methodSchema) {
   const match = getMatchFn(normalizedSchema);
 
   function validateParams(ctx, params) {
-    const args = match(params);
-    ctx.swatchCtx.args = args;
+    const result = match(params);
+    ctx.swatchCtx.values = result.values; // Array of ordered args
+    ctx.swatchCtx.params = result.params; // Dict of params by name
   }
 
   function handleMethod(ctx) {
-    const args = ctx.swatchCtx.args;
+    const args = ctx.swatchCtx.values;
     return normalizedSchema.handler.apply(null, args);
   }
 

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -6,10 +6,11 @@ const validate = validator(serviceSchema);
 
 function load(api) {
   function prepare(key) {
-    const metadata = methodSchema.metadata || {};
-
     const methodSchema = api[key];
     const methodHandler = handler(methodSchema);
+
+    const metadata = methodSchema.metadata || {};
+
     return {
       name: key,
       match: methodHandler.match,

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -13,8 +13,8 @@ function load(api) {
 
     return {
       name: key,
-      match: methodHandler.match,
       handle: methodHandler.handle,
+      validate: methodHandler.validate,
       metadata: {
         noAuth: metadata.noAuth || false,
         middleware: metadata.middleware || [],

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -6,12 +6,14 @@ const validate = validator(serviceSchema);
 
 function load(api) {
   function prepare(key) {
-    const methodSchema = api[key];
     const metadata = methodSchema.metadata || {};
 
+    const methodSchema = api[key];
+    const methodHandler = handler(methodSchema);
     return {
       name: key,
-      handle: handler(methodSchema),
+      match: methodHandler.match,
+      handle: methodHandler.handle,
       metadata: {
         noAuth: metadata.noAuth || false,
         middleware: metadata.middleware || [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "0.2.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -134,9 +134,9 @@
       "dev": true
     },
     "babel-code-frame": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
@@ -561,7 +561,7 @@
       "dev": true,
       "requires": {
         "ajv": "5.2.2",
-        "babel-code-frame": "6.22.0",
+        "babel-code-frame": "6.26.0",
         "chalk": "1.1.3",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "0.2.2",
+  "version": "1.0.0",
   "description": "Framework for easily creating and exposing APIs as methods",
   "main": "lib/index.js",
   "scripts": {

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -5,7 +5,7 @@ function execHandler(handle, args) {
   const mockCtx = {
     swatchCtx: {},
   };
-  handle.match(mockCtx, args);
+  handle.validate(mockCtx, args);
   return handle.handle(mockCtx);
 }
 

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -1,6 +1,14 @@
 const expect = require('chai').expect;
 const handler = require('../lib/handler');
 
+function execHandler(handle, args) {
+  const mockCtx = {
+    swatchCtx: {},
+  };
+  handle.match(mockCtx, args);
+  return handle.handle(mockCtx);
+}
+
 describe('handler', () => {
   describe('load time', () => {
     it('should throw if args are provided and arity doesnt match', () => {
@@ -92,15 +100,15 @@ describe('handler', () => {
     });
 
     it('should throw if all required parameters were not passed', () => {
-      expect(() => handle({ a: 1 })).to.throw('missing_arg');
+      expect(() => execHandler(handle, { a: 1 })).to.throw('missing_arg');
     });
 
     it('should throw if a required parameter was undefined', () => {
-      expect(() => handle({ a: 1, b: undefined })).to.throw('missing_arg');
+      expect(() => execHandler(handle, { a: 1, b: undefined })).to.throw('missing_arg');
     });
 
     it('should throw if a parameter passed was not expected', () => {
-      expect(() => handle({ a: 1, b: 2, c: 3 })).to.throw('invalid_arg_name');
+      expect(() => execHandler(handle, { a: 1, b: 2, c: 3 })).to.throw('invalid_arg_name');
     });
 
     it('should invoke the handler if all required arguments were passed', () => {
@@ -123,7 +131,7 @@ describe('handler', () => {
           },
         ],
       };
-      const result = handler(method)({ a: 1, b: 2 });
+      const result = execHandler(handler(method), { a: 1, b: 2 });
       expect(result).to.equal(3);
     });
 
@@ -135,8 +143,8 @@ describe('handler', () => {
           { name: 'c' },
         ],
       };
-      expect(() => handler(api)({ a: '.', b: '.' })).to.throw();
-      expect(() => handler(api)({ a: '.', c: '.' })).not.to.throw();
+      expect(() => execHandler(handler(api), { a: '.', b: '.' })).to.throw();
+      expect(() => execHandler(handler(api), { a: '.', c: '.' })).not.to.throw();
     });
   });
 
@@ -147,11 +155,11 @@ describe('handler', () => {
     });
 
     it('should throw if all required parameters were not passed', () => {
-      expect(() => handle({ x: '1' })).to.throw('missing_arg');
+      expect(() => execHandler(handle, { x: '1' })).to.throw('missing_arg');
     });
 
     it('should throw if a parameter passed was not expected', () => {
-      expect(() => handle({ w: '0', x: '1', y: '2', z: '3' })).to.throw('invalid_arg_name');
+      expect(() => execHandler(handle, { w: '0', x: '1', y: '2', z: '3' })).to.throw('invalid_arg_name');
     });
 
     it('should invoke the handler if all required arguments were passed', () => {
@@ -168,7 +176,7 @@ describe('handler', () => {
         handler: fn,
         args: ['x', 'y', 'z'],
       };
-      const result = handler(method)({ z: '3', y: '2', x: '1' });
+      const result = execHandler(handler(method), { z: '3', y: '2', x: '1' });
       expect(result).to.equal('123');
     });
 
@@ -190,11 +198,11 @@ describe('handler', () => {
           { parse: String },
         ],
       };
-      const result = handler(method)({ c: '3', x: '2', y: '1' });
+      const result = execHandler(handler(method), { c: '3', x: '2', y: '1' });
       expect(result).to.equal('123');
 
-      expect(() => handler(method)({ a: '1', b: '2', c: '3' })).to.throw('invalid_arg_name');
-      expect(() => handler(method)({ x: '1', y: '2', z: '3' })).to.throw('invalid_arg_name');
+      expect(() => execHandler(handler(method), { a: '1', b: '2', c: '3' })).to.throw('invalid_arg_name');
+      expect(() => execHandler(handler(method), { x: '1', y: '2', z: '3' })).to.throw('invalid_arg_name');
     });
   });
 
@@ -208,11 +216,11 @@ describe('handler', () => {
     });
 
     it('should throw if all required parameters were not passed', () => {
-      expect(() => handle({ a: 1 })).to.throw('missing_arg');
+      expect(() => execHandler(handle, { a: 1 })).to.throw('missing_arg');
     });
 
     it('should throw if a parameter passed was not expected', () => {
-      expect(() => handle({ a: 1, b: 2, c: 3 })).to.throw('invalid_arg_name');
+      expect(() => execHandler(handle, { a: 1, b: 2, c: 3 })).to.throw('invalid_arg_name');
     });
 
     it('should invoke the handler if all required arguments were passed', () => {
@@ -229,7 +237,7 @@ describe('handler', () => {
           { parse: Number },
         ],
       };
-      const result = handler(method)({ b: 2, a: 1 });
+      const result = execHandler(handler(method), { b: 2, a: 1 });
       expect(result).to.equal(3);
     });
   });
@@ -240,11 +248,11 @@ describe('handler', () => {
     });
 
     it('should throw if all required parameters were not passed', () => {
-      expect(() => handle({ a: 1 })).to.throw('missing_arg');
+      expect(() => execHandler(handle, { a: 1 })).to.throw('missing_arg');
     });
 
     it('should throw if a parameter passed was not expected', () => {
-      expect(() => handle({ a: 1, b: 2, c: 3 })).to.throw('invalid_arg_name');
+      expect(() => execHandler(handle, { a: 1, b: 2, c: 3 })).to.throw('invalid_arg_name');
     });
 
     it('should invoke the handler if all required arguments were passed', () => {
@@ -257,7 +265,7 @@ describe('handler', () => {
       const method = {
         handler: fn,
       };
-      const result = handler(method)({ a: 1, b: 2 });
+      const result = execHandler(handler(method), { a: 1, b: 2 });
       expect(result).to.equal(3);
     });
   });
@@ -274,12 +282,12 @@ describe('handler', () => {
     });
 
     it('should invoke the handler if optional arguments were omitted', () => {
-      const result = handle({});
+      const result = execHandler(handle, {});
       expect(result).to.equal(undefined);
     });
 
     it('should invoke the handler if optional arguments were passed', () => {
-      const result = handle({ a: 'hello' });
+      const result = execHandler(handle, { a: 'hello' });
       expect(result).to.equal('hello');
     });
   });
@@ -305,20 +313,21 @@ describe('handler', () => {
     };
 
     // Framework should explicitly throw on missing or undefined values
-    expect(() => handler(method)({})).to.throw('missing_arg');
-    expect(() => handler(method)({ argNum: undefined })).to.throw('missing_arg');
+    const handle = handler(method);
+    expect(() => execHandler(handle, {})).to.throw('missing_arg');
+    expect(() => execHandler(handle, { argNum: undefined })).to.throw('missing_arg');
 
     // Otherwise it should accept the values and run the parser
-    const resultZero = handler(method)({ argNum: 0 });
+    const resultZero = execHandler(handle, { argNum: 0 });
     expect(resultZero).to.equal(false);
 
-    const resultUndefined = handler(method)({ argNum: null });
+    const resultUndefined = execHandler(handle, { argNum: null });
     expect(resultUndefined).to.equal(true);
 
-    const resultFalse = handler(method)({ argNum: false });
+    const resultFalse = execHandler(handle, { argNum: false });
     expect(resultFalse).to.equal(true);
 
-    const resultNumber = handler(method)({ argNum: 1 });
+    const resultNumber = execHandler(handle, { argNum: 1 });
     expect(resultNumber).to.equal(true);
   });
 
@@ -343,7 +352,7 @@ describe('handler', () => {
         },
       ],
     };
-    expect(() => handler(method)({ arg: -1 })).to.throw('negative_number');
+    expect(() => execHandler(handler(method), { arg: -1 })).to.throw('negative_number');
   });
 
   describe('default values', () => {
@@ -360,8 +369,9 @@ describe('handler', () => {
           },
         ],
       };
-      expect(handler(method)({ a: 2 })).to.equal(2);
-      expect(() => handler(method)({})).to.throw('missing_arg');
+      const handle = handler(method);
+      expect(execHandler(handle, { a: 2 })).to.equal(2);
+      expect(() => execHandler(handle, {})).to.throw('missing_arg');
     });
 
     it('should use default values for optional argument when undefined', () => {
@@ -399,6 +409,7 @@ describe('handler', () => {
           },
         ],
       };
+      const handle = handler(method);
 
       function checkResult(result, a, b, c, d) {
         expect(result.a).to.equal(a);
@@ -411,16 +422,16 @@ describe('handler', () => {
         });
       }
 
-      const r1 = handler(method)({});
+      const r1 = execHandler(handle, {});
       checkResult(r1, 0, false, [], '');
 
-      const r2 = handler(method)({ a: '100', b: true });
+      const r2 = execHandler(handle, { a: '100', b: true });
       checkResult(r2, 100, true, [], '');
 
-      const r3 = handler(method)({ b: false, c: [0] });
+      const r3 = execHandler(handle, { b: false, c: [0] });
       checkResult(r3, 0, false, [0], '');
 
-      const r4 = handler(method)({ c: [], d: 'false' });
+      const r4 = execHandler(handle, { c: [], d: 'false' });
       checkResult(r4, 0, false, [], 'false');
     });
   });

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -355,6 +355,40 @@ describe('handler', () => {
     expect(() => execHandler(handler(method), { arg: -1 })).to.throw('negative_number');
   });
 
+  describe('validate params', () => {
+    it('should provide access to validated params', () => {
+      const fn = (a, b, c) => ({ a, b, c });
+      const method = {
+        handler: fn,
+        args: [
+          {
+            name: 'a',
+            parse: Number,
+          },
+          {
+            name: 'b',
+            parse: Boolean,
+          },
+          {
+            name: 'c',
+            parse: String,
+          },
+        ],
+      };
+      const handle = handler(method);
+
+      const mockCtx = {
+        swatchCtx: {},
+      };
+      handle.validate(mockCtx, { a: '100', b: true, c: 'Success' });
+
+      expect(mockCtx.swatchCtx.values).to.deep.equal([100, true, 'Success']);
+      expect(mockCtx.swatchCtx.params.a).to.equal(100);
+      expect(mockCtx.swatchCtx.params.b).to.equal(true);
+      expect(mockCtx.swatchCtx.params.c).to.equal('Success');
+    });
+  });
+
   describe('default values', () => {
     it('should not use default values for required arguments', () => {
       const fn = a => (a);

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -3,8 +3,9 @@ const load = require('../lib/loader');
 
 function validate(model) {
   model.forEach((method) => {
-    expect(method).to.be.an('object').that.has.all.keys('name', 'handle', 'metadata');
+    expect(method).to.be.an('object').that.has.all.keys('name', 'match', 'handle', 'metadata');
     expect(method.name).to.be.a('string');
+    expect(method.match).to.be.a('function');
     expect(method.handle).to.be.a('function');
 
     expect(method.metadata).to.be.an('object').that.has.all.keys('noAuth', 'middleware');

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -3,10 +3,10 @@ const load = require('../lib/loader');
 
 function validate(model) {
   model.forEach((method) => {
-    expect(method).to.be.an('object').that.has.all.keys('name', 'match', 'handle', 'metadata');
+    expect(method).to.be.an('object').that.has.all.keys('name', 'handle', 'validate', 'metadata');
     expect(method.name).to.be.a('string');
-    expect(method.match).to.be.a('function');
     expect(method.handle).to.be.a('function');
+    expect(method.validate).to.be.a('function');
 
     expect(method.metadata).to.be.an('object').that.has.all.keys('noAuth', 'middleware');
     expect(method.metadata.noAuth).to.be.an('boolean');


### PR DESCRIPTION
In order to allow the various swatch-* frameworks to let consumers write middleware that operate on already validated parameters, split up the behavior that currently lives in the handler.

Today, the final step in the method execution is to validate parameters and then execute the method. The desired flow is to validate the params first, and move them to a standard location that will allow any custom middleware to use them, then finally pass them into the handler.