### PR TITLE
Error Messages Now Include Details

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,5 +7,8 @@
         "ecmaVersion": 8,
         "sourceType": "module",
         "ecmaFeatures": {}
+    },
+    "rules": {
+      "no-throw-literal": 0
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # swatchjs
 
 [![CircleCI](https://circleci.com/gh/builtforme/swatchjs.svg?style=svg)](https://circleci.com/gh/builtforme/swatchjs) |
-[![codecov](https://codecov.io/gh/builtforme/swatchjs/branch/master/graph/badge.svg)](https://codecov.io/gh/builtforme/swatchjs) | [![Coverage Status](https://coveralls.io/repos/github/builtforme/swatchjs-koa/badge.svg?branch=master)](https://coveralls.io/github/builtforme/swatchjs-koa?branch=master) | [![Known Vulnerabilities](https://snyk.io/test/github/builtforme/swatchjs/badge.svg)](https://snyk.io/test/github/builtforme/swatchjs)
+[![codecov](https://codecov.io/gh/builtforme/swatchjs/branch/master/graph/badge.svg)](https://codecov.io/gh/builtforme/swatchjs) | [![Coverage Status](https://coveralls.io/repos/github/builtforme/swatchjs/badge.svg?branch=master)](https://coveralls.io/github/builtforme/swatchjs?branch=master) | [![Known Vulnerabilities](https://snyk.io/test/github/builtforme/swatchjs/badge.svg)](https://snyk.io/test/github/builtforme/swatchjs)
 
 A framework for easily creating and exposing APIs as methods.
 

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -18,7 +18,10 @@ function getMatchFn(methodSchema) {
   //  If so, first validate that schema and function have same arity
   if (methodSchema.args !== undefined) {
     if (methodSchema.args.length !== functionArgs.length) {
-      throw errors.INVALID_ARG_LIST;
+      throw {
+        message: errors.INVALID_ARG_LIST,
+        details: `Expected ${functionArgs.length} arguments but found ${methodSchema.args.length} instead.`,
+      };
     }
   }
 
@@ -46,7 +49,10 @@ function getMatchFn(methodSchema) {
       try {
         arg.validate(arg.default);
       } catch (err) {
-        throw errors.INVALID_DEFAULT;
+        throw {
+          message: errors.INVALID_DEFAULT,
+          details: `Default value "${arg.default}" for argument ${arg.name} did not pass validation.`,
+        };
       }
     }
 
@@ -71,7 +77,10 @@ function getMatchFn(methodSchema) {
   function matcher(args) {
     Object.keys(args).forEach((arg) => {
       if (!expectedArgNames.includes(arg)) {
-        throw errors.INVALID_ARG_NAME;
+        throw {
+          message: errors.INVALID_ARG_NAME,
+          details: `Extraneous argument "${arg}".`,
+        };
       }
     });
 
@@ -79,7 +88,10 @@ function getMatchFn(methodSchema) {
       let passed = args[arg.name];
       if (passed === undefined) {
         if (!arg.optional) {
-          throw errors.MISSING_ARG;
+          throw {
+            message: errors.MISSING_ARG,
+            details: `Required argument "${arg.name}"" missing.`,
+          };
         }
         passed = arg.default;
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Framework for easily creating and exposing APIs as methods",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
With this PR:
1. Error messages are no longer just a string but rather an object which contains the original string as `message` and some details as, well, `details`. This will make it easier to troubleshoot as a consumer of a swatch-based service because the consumer will now receive information about which arguments are missing or extraneous, instead of having to guess.
2. The `.eslintrc` is updated to turn off the ESLint rule `no-throw-literal`. In practice nothing is changing since we were throwing literals previously, but because we now throw a literally directly instead of a reference to a string, ESLint can now determine we are throwing literals and complain. Previously ESLint did not know that the variable being thrown was not an Error object, and thus did not complain. See all details at [the no-throw-literal documentation page](http://eslint.org/docs/rules/no-throw-literal).
3. One of the coverage badges was mistakenly pointing to swatchjs-koa, which this repo is most certainly not. That minor fix has been rolled into the PR.