### PR TITLE
Use "off" instead of 0 in .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,6 @@
         "ecmaFeatures": {}
     },
     "rules": {
-      "no-throw-literal": 0
+      "no-throw-literal": "off"
     }
 }


### PR DESCRIPTION
Per feedback in https://github.com/builtforme/swatchjs/pull/25, using "off" is clearer as to intent. There is no version bump in this PR because we do not need to publish this change to npm (and thus the CI publish job is expected to fail).