### PR TITLE
Pass the swatchCtx object as 'this' param for handlers

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -129,7 +129,7 @@ function handler(methodSchema) {
 
   function handleMethod(ctx) {
     const args = ctx.swatchCtx.values;
-    return normalizedSchema.handler.apply(null, args);
+    return normalizedSchema.handler.apply(ctx.swatchCtx, args);
   }
 
   return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Framework for easily creating and exposing APIs as methods",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Framework for easily creating and exposing APIs as methods",
   "main": "lib/index.js",
   "scripts": {

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -3,7 +3,9 @@ const handler = require('../lib/handler');
 
 function execHandler(handle, args) {
   const mockCtx = {
-    swatchCtx: {},
+    swatchCtx: {
+      testVal: 100,
+    },
   };
   handle.validate(mockCtx, args);
   return handle.handle(mockCtx);
@@ -386,6 +388,29 @@ describe('handler', () => {
       expect(mockCtx.swatchCtx.params.a).to.equal(100);
       expect(mockCtx.swatchCtx.params.b).to.equal(true);
       expect(mockCtx.swatchCtx.params.c).to.equal('Success');
+    });
+  });
+
+  describe('context', () => {
+    it('should pass the swatchCtx as this param in final handler', () => {
+      function fn(a, b) {
+        return a + b + this.testVal;
+      }
+      const method = {
+        handler: fn,
+        args: [
+          {
+            name: 'a',
+            parse: Number,
+          },
+          {
+            name: 'b',
+            parse: Number,
+          },
+        ],
+      };
+      const handle = handler(method);
+      expect(execHandler(handle, { a: '25', b: '50' })).to.equal(175);
     });
   });
 


### PR DESCRIPTION
There will be cases where clients do work in middleware and want to cache results on the swatchCtx, so we pass the swatchCtx as the `this` object for handlers to access that data