### PR TITLE
Modify the SwatchCTX storing function keys instead of values

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -84,6 +84,8 @@ function getMatchFn(methodSchema) {
       }
     });
 
+    const keys = argsMetadata.map(arg => arg.name);
+
     const values = argsMetadata.map((arg) => {
       let passed = args[arg.name];
       if (passed === undefined) {
@@ -109,7 +111,7 @@ function getMatchFn(methodSchema) {
     });
 
     return {
-      values,
+      keys,
       params,
     };
   }
@@ -123,12 +125,14 @@ function handler(methodSchema) {
 
   function validateParams(ctx, params) {
     const result = match(params);
-    ctx.swatchCtx.values = result.values; // Array of ordered args
+    ctx.swatchCtx.keys = result.keys; // Array of ordered arg names
     ctx.swatchCtx.params = result.params; // Dict of params by name
   }
 
   function handleMethod(ctx) {
-    const args = ctx.swatchCtx.values;
+    const args = ctx.swatchCtx.keys.map(key => (
+      ctx.swatchCtx.params[key]
+    ));
     return normalizedSchema.handler.apply(ctx.swatchCtx, args);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3736,15 +3736,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -3770,6 +3761,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Framework for easily creating and exposing APIs as methods",
   "main": "lib/index.js",
   "scripts": {

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -384,7 +384,7 @@ describe('handler', () => {
       };
       handle.validate(mockCtx, { a: '100', b: true, c: 'Success' });
 
-      expect(mockCtx.swatchCtx.values).to.deep.equal([100, true, 'Success']);
+      expect(mockCtx.swatchCtx.keys).to.deep.equal(['a', 'b', 'c']);
       expect(mockCtx.swatchCtx.params.a).to.equal(100);
       expect(mockCtx.swatchCtx.params.b).to.equal(true);
       expect(mockCtx.swatchCtx.params.c).to.equal('Success');


### PR DESCRIPTION
The Swatch CTX provides handler functions with a 'params' property so that any middleware can grab the validated values and optionally change/write back to the 'params' dict before the handler gets called. (This will let clients do some validation or parsing on parameters that require knowledge of other function params).

Currently we store an ordered array of 'values' which eventually get passed into the handler. Since the client should be able to modify values in the 'params' dict, duplicating the parameter in two places is a problem. So instead we should store the 'keys' in order, and when we execute the function, just map the keys to an array with the latest parameters from the 'params' dict.