### PR TITLE
Add a safe log message to log params before and after parsing/validation

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -10,6 +10,14 @@ function normalize(method) {
   return method;
 }
 
+function safeLog(ctx, message) {
+  // Helper function to log validation and request info
+  //  Checks for an available swatch logger before logging
+  if (ctx.swatchCtx.logger) {
+    ctx.swatchCtx.logger.info(message);
+  }
+}
+
 function getMatchFn(methodSchema) {
   // Get string names of arguments defined in the handler function
   const functionArgs = fnArgs(methodSchema.handler);
@@ -79,7 +87,7 @@ function getMatchFn(methodSchema) {
       if (!expectedArgNames.includes(arg)) {
         throw {
           message: errors.INVALID_ARG_NAME,
-          details: `Extraneous argument "${arg}".`,
+          details: `Unexpected argument "${arg}".`,
         };
       }
     });
@@ -124,6 +132,8 @@ function handler(methodSchema) {
   const match = getMatchFn(normalizedSchema);
 
   function validateParams(ctx, params) {
+    safeLog(ctx, `Validating request parameters: ${params}`);
+
     const result = match(params);
     ctx.swatchCtx.keys = result.keys; // Array of ordered arg names
     ctx.swatchCtx.params = result.params; // Dict of params by name
@@ -133,6 +143,8 @@ function handler(methodSchema) {
     const args = ctx.swatchCtx.keys.map(key => (
       ctx.swatchCtx.params[key]
     ));
+    safeLog(ctx, `Executing swatch handler with arguments: ${args}`);
+
     return normalizedSchema.handler.apply(ctx.swatchCtx, args);
   }
 

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -1,3 +1,5 @@
+const util = require('util');
+
 const fnArgs = require('function-arguments');
 const errors = require('./errors');
 
@@ -132,7 +134,7 @@ function handler(methodSchema) {
   const match = getMatchFn(normalizedSchema);
 
   function validateParams(ctx, params) {
-    safeLog(ctx, `Validating request parameters: ${params}`);
+    safeLog(ctx, `Validating request parameters: ${util.inspect(params)}`);
 
     const result = match(params);
     ctx.swatchCtx.keys = result.keys; // Array of ordered arg names
@@ -143,7 +145,7 @@ function handler(methodSchema) {
     const args = ctx.swatchCtx.keys.map(key => (
       ctx.swatchCtx.params[key]
     ));
-    safeLog(ctx, `Executing swatch handler with arguments: ${args}`);
+    safeLog(ctx, `Executing swatch handler with arguments: ${util.inspect(args)}`);
 
     return normalizedSchema.handler.apply(ctx.swatchCtx, args);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "swatchjs",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "acorn": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
       "dev": true
     },
     "acorn-jsx": {
@@ -44,9 +44,9 @@
       "dev": true
     },
     "ansi-escapes": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
-      "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
       "dev": true
     },
     "ansi-regex": {
@@ -221,14 +221,14 @@
       "dev": true
     },
     "chai": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.1.tgz",
-      "integrity": "sha1-ZuISeebzxkFf+CMYeCJ5AOIXGzk=",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
         "assertion-error": "1.0.2",
         "check-error": "1.0.2",
-        "deep-eql": "2.0.2",
+        "deep-eql": "3.0.1",
         "get-func-name": "2.0.0",
         "pathval": "1.1.0",
         "type-detect": "4.0.3"
@@ -269,9 +269,9 @@
       }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "co": {
@@ -377,7 +377,7 @@
           "requires": {
             "chalk": "1.1.3",
             "commander": "2.11.0",
-            "is-my-json-valid": "2.16.0",
+            "is-my-json-valid": "2.16.1",
             "pinkie-promise": "2.0.1"
           }
         },
@@ -406,11 +406,11 @@
             "is-typedarray": "1.0.0",
             "isstream": "0.1.2",
             "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.16",
+            "mime-types": "2.1.17",
             "oauth-sign": "0.8.2",
             "qs": "6.3.2",
             "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
+            "tough-cookie": "2.3.3",
             "tunnel-agent": "0.4.3",
             "uuid": "3.1.0"
           }
@@ -461,29 +461,21 @@
       }
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.0.1.tgz",
+      "integrity": "sha512-6nVc6S36qbt/mutyt+UGMnawAMrPDZUPQjRZI3FS9tCtDRhvxJbK79unYBLPi+z5SLXQ3ftoVBFCblQtNSls8w==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
     },
     "deep-eql": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
-      "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "3.0.0"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-3.0.0.tgz",
-          "integrity": "sha1-RtDMhVOrt7E6NSsNbeov1Y8tm1U=",
-          "dev": true
-        }
+        "type-detect": "4.0.3"
       }
     },
     "deep-is": {
@@ -504,7 +496,7 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       }
     },
     "delayed-stream": {
@@ -555,20 +547,20 @@
       "dev": true
     },
     "eslint": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.4.1.tgz",
-      "integrity": "sha1-mc1+r8/8ov+Zpcj18qR01jZLS9M=",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.7.2.tgz",
+      "integrity": "sha1-/29fUZOEiifum2J74+c/ucteZi4=",
       "dev": true,
       "requires": {
         "ajv": "5.2.2",
         "babel-code-frame": "6.26.0",
-        "chalk": "1.1.3",
+        "chalk": "2.1.0",
         "concat-stream": "1.6.0",
         "cross-spawn": "5.1.0",
-        "debug": "2.6.8",
+        "debug": "3.0.1",
         "doctrine": "2.0.0",
         "eslint-scope": "3.7.1",
-        "espree": "3.5.0",
+        "espree": "3.5.1",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
@@ -576,11 +568,11 @@
         "functional-red-black-tree": "1.0.1",
         "glob": "7.1.2",
         "globals": "9.18.0",
-        "ignore": "3.3.3",
+        "ignore": "3.3.5",
         "imurmurhash": "0.1.4",
-        "inquirer": "3.2.2",
+        "inquirer": "3.3.0",
         "is-resolvable": "1.0.0",
-        "js-yaml": "3.9.1",
+        "js-yaml": "3.10.0",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
@@ -589,10 +581,11 @@
         "natural-compare": "1.4.0",
         "optionator": "0.8.2",
         "path-is-inside": "1.0.2",
-        "pluralize": "4.0.0",
+        "pluralize": "7.0.0",
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
         "semver": "5.4.1",
+        "strip-ansi": "4.0.0",
         "strip-json-comments": "2.0.1",
         "table": "4.0.1",
         "text-table": "0.2.0"
@@ -610,6 +603,32 @@
             "json-stable-stringify": "1.0.1"
           }
         },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.4.0"
+          }
+        },
         "esprima": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
@@ -617,21 +636,39 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.9.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
-          "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
           "dev": true,
           "requires": {
             "argparse": "1.0.9",
             "esprima": "4.0.0"
           }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
         }
       }
     },
     "eslint-config-airbnb-base": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.3.1.tgz",
-      "integrity": "sha512-BXVH7PV5yiLjnkv49iOLJ8dWp+ljZf310ytQpqwrunFADiEbWRyN0tPGDU36FgEbdLvhJDWcJOngYDzPF4shDw==",
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.3.2.tgz",
+      "integrity": "sha512-/fhjt/VqzBA2SRsx7ErDtv6Ayf+XLw9LIOqmpBuHFCVwyJo2EtzGWMB9fYRFBoWWQLxmNmCpenNiH0RxyeS41w==",
       "dev": true,
       "requires": {
         "eslint-restricted-globals": "0.1.1"
@@ -643,8 +680,19 @@
       "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "resolve": "1.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "eslint-module-utils": {
@@ -653,8 +701,19 @@
       "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "pkg-dir": "1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "eslint-plugin-import": {
@@ -665,7 +724,7 @@
       "requires": {
         "builtin-modules": "1.1.1",
         "contains-path": "0.1.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "0.3.1",
         "eslint-module-utils": "2.1.1",
@@ -675,6 +734,15 @@
         "read-pkg-up": "2.0.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
@@ -704,12 +772,12 @@
       }
     },
     "espree": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
-      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
+      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
       "dev": true,
       "requires": {
-        "acorn": "5.1.1",
+        "acorn": "5.1.2",
         "acorn-jsx": "3.0.1"
       }
     },
@@ -757,14 +825,14 @@
       "dev": true
     },
     "external-editor": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
-      "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
+      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
       "dev": true,
       "requires": {
-        "iconv-lite": "0.4.18",
+        "iconv-lite": "0.4.19",
         "jschardet": "1.5.1",
-        "tmp": "0.0.31"
+        "tmp": "0.0.33"
       }
     },
     "extsprintf": {
@@ -840,7 +908,7 @@
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
-        "mime-types": "2.1.16"
+        "mime-types": "2.1.17"
       }
     },
     "fs.realpath": {
@@ -855,9 +923,9 @@
       "integrity": "sha1-uaAdrKa4lO/4w9NoQDde2WNqbA8="
     },
     "function-bind": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "functional-red-black-tree": {
@@ -988,7 +1056,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.0"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -1026,6 +1094,12 @@
         }
       }
     },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
     "hoek": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
@@ -1049,15 +1123,15 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
     },
     "ignore": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
       "dev": true
     },
     "imurmurhash": {
@@ -1083,16 +1157,16 @@
       "dev": true
     },
     "inquirer": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.2.tgz",
-      "integrity": "sha512-bTKLzEHJVATimZO/YFdLrom0lRx1BHfRYskFHfIMVkGdp8+dIZaxuU+4yrsS1lcu6YWywVQVVsfvdwESzbeqHw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "2.0.0",
+        "ansi-escapes": "3.0.0",
         "chalk": "2.1.0",
         "cli-cursor": "2.1.0",
-        "cli-width": "2.1.0",
-        "external-editor": "2.0.4",
+        "cli-width": "2.2.0",
+        "external-editor": "2.0.5",
         "figures": "2.0.0",
         "lodash": "4.17.4",
         "mute-stream": "0.0.7",
@@ -1127,7 +1201,7 @@
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.2.1"
+            "supports-color": "4.4.0"
           }
         },
         "strip-ansi": {
@@ -1140,9 +1214,9 @@
           }
         },
         "supports-color": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -1172,9 +1246,9 @@
       "dev": true
     },
     "is-my-json-valid": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
       "dev": true,
       "requires": {
         "generate-function": "2.0.0",
@@ -1510,18 +1584,18 @@
       }
     },
     "mime-db": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
-      "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-      "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "dev": true,
       "requires": {
-        "mime-db": "1.29.0"
+        "mime-db": "1.30.0"
       }
     },
     "mimic-fn": {
@@ -1563,9 +1637,9 @@
       }
     },
     "mocha": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
-      "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -1575,6 +1649,7 @@
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.1",
         "growl": "1.9.2",
+        "he": "1.1.1",
         "json3": "3.3.2",
         "lodash.create": "3.1.1",
         "mkdirp": "0.5.1",
@@ -1588,6 +1663,15 @@
           "dev": true,
           "requires": {
             "graceful-readlink": "1.0.1"
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
           }
         },
         "glob": {
@@ -1628,7 +1712,7 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "eslint": "4.4.1",
+        "eslint": "4.7.2",
         "glob-all": "3.1.0",
         "replaceall": "0.1.6"
       }
@@ -1664,9 +1748,9 @@
       }
     },
     "nyc": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.1.0.tgz",
-      "integrity": "sha1-1rPF4WiSolr2MTi6SEZ2qooi7ac=",
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.2.1.tgz",
+      "integrity": "sha1-rYUK/p261/SXByi0suR/7Rw4chw=",
       "dev": true,
       "requires": {
         "archy": "1.0.0",
@@ -1681,10 +1765,10 @@
         "glob": "7.1.2",
         "istanbul-lib-coverage": "1.1.1",
         "istanbul-lib-hook": "1.0.7",
-        "istanbul-lib-instrument": "1.7.4",
+        "istanbul-lib-instrument": "1.8.0",
         "istanbul-lib-report": "1.1.1",
         "istanbul-lib-source-maps": "1.2.1",
-        "istanbul-reports": "1.1.1",
+        "istanbul-reports": "1.1.2",
         "md5-hex": "1.3.0",
         "merge-source-map": "1.0.4",
         "micromatch": "2.3.11",
@@ -1765,7 +1849,7 @@
           "dev": true
         },
         "babel-code-frame": {
-          "version": "6.22.0",
+          "version": "6.26.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -1775,17 +1859,17 @@
           }
         },
         "babel-generator": {
-          "version": "6.25.0",
+          "version": "6.26.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "babel-messages": "6.23.0",
-            "babel-runtime": "6.23.0",
-            "babel-types": "6.25.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
             "detect-indent": "4.0.0",
             "jsesc": "1.3.0",
             "lodash": "4.17.4",
-            "source-map": "0.5.6",
+            "source-map": "0.5.7",
             "trim-right": "1.0.1"
           }
         },
@@ -1794,40 +1878,40 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.23.0"
+            "babel-runtime": "6.26.0"
           }
         },
         "babel-runtime": {
-          "version": "6.23.0",
+          "version": "6.26.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-js": "2.4.1",
-            "regenerator-runtime": "0.10.5"
+            "core-js": "2.5.1",
+            "regenerator-runtime": "0.11.0"
           }
         },
         "babel-template": {
-          "version": "6.25.0",
+          "version": "6.26.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.23.0",
-            "babel-traverse": "6.25.0",
-            "babel-types": "6.25.0",
-            "babylon": "6.17.4",
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
             "lodash": "4.17.4"
           }
         },
         "babel-traverse": {
-          "version": "6.25.0",
+          "version": "6.26.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.22.0",
+            "babel-code-frame": "6.26.0",
             "babel-messages": "6.23.0",
-            "babel-runtime": "6.23.0",
-            "babel-types": "6.25.0",
-            "babylon": "6.17.4",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
             "debug": "2.6.8",
             "globals": "9.18.0",
             "invariant": "2.2.2",
@@ -1835,18 +1919,18 @@
           }
         },
         "babel-types": {
-          "version": "6.25.0",
+          "version": "6.26.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-runtime": "6.23.0",
+            "babel-runtime": "6.26.0",
             "esutils": "2.0.2",
             "lodash": "4.17.4",
             "to-fast-properties": "1.0.3"
           }
         },
         "babylon": {
-          "version": "6.17.4",
+          "version": "6.18.0",
           "bundled": true,
           "dev": true
         },
@@ -1957,7 +2041,7 @@
           "dev": true
         },
         "core-js": {
-          "version": "2.4.1",
+          "version": "2.5.1",
           "bundled": true,
           "dev": true
         },
@@ -1967,7 +2051,7 @@
           "dev": true,
           "requires": {
             "lru-cache": "4.1.1",
-            "which": "1.2.14"
+            "which": "1.3.0"
           }
         },
         "debug": {
@@ -2023,17 +2107,29 @@
           "dev": true
         },
         "execa": {
-          "version": "0.5.1",
+          "version": "0.7.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "4.0.2",
-            "get-stream": "2.3.1",
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
             "is-stream": "1.1.0",
             "npm-run-path": "2.0.2",
             "p-finally": "1.0.0",
             "signal-exit": "3.0.2",
             "strip-eof": "1.0.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "lru-cache": "4.1.1",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
+              }
+            }
           }
         },
         "expand-brackets": {
@@ -2128,13 +2224,9 @@
           "dev": true
         },
         "get-stream": {
-          "version": "2.3.1",
+          "version": "3.0.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-assign": "4.1.1",
-            "pinkie-promise": "2.0.1"
-          }
+          "dev": true
         },
         "glob": {
           "version": "7.1.2",
@@ -2372,17 +2464,17 @@
           }
         },
         "istanbul-lib-instrument": {
-          "version": "1.7.4",
+          "version": "1.8.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "babel-generator": "6.25.0",
-            "babel-template": "6.25.0",
-            "babel-traverse": "6.25.0",
-            "babel-types": "6.25.0",
-            "babylon": "6.17.4",
+            "babel-generator": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
             "istanbul-lib-coverage": "1.1.1",
-            "semver": "5.3.0"
+            "semver": "5.4.1"
           }
         },
         "istanbul-lib-report": {
@@ -2415,11 +2507,11 @@
             "istanbul-lib-coverage": "1.1.1",
             "mkdirp": "0.5.1",
             "rimraf": "2.6.1",
-            "source-map": "0.5.6"
+            "source-map": "0.5.7"
           }
         },
         "istanbul-reports": {
-          "version": "1.1.1",
+          "version": "1.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -2539,7 +2631,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "source-map": "0.5.6"
+            "source-map": "0.5.7"
           }
         },
         "micromatch": {
@@ -2559,7 +2651,7 @@
             "normalize-path": "2.1.1",
             "object.omit": "2.0.1",
             "parse-glob": "3.0.4",
-            "regex-cache": "0.4.3"
+            "regex-cache": "0.4.4"
           }
         },
         "mimic-fn": {
@@ -2600,7 +2692,7 @@
           "requires": {
             "hosted-git-info": "2.5.0",
             "is-builtin-module": "1.0.0",
-            "semver": "5.3.0",
+            "semver": "5.4.1",
             "validate-npm-package-license": "3.0.1"
           }
         },
@@ -2609,7 +2701,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "1.0.2"
+            "remove-trailing-separator": "1.1.0"
           }
         },
         "npm-run-path": {
@@ -2662,11 +2754,11 @@
           "dev": true
         },
         "os-locale": {
-          "version": "2.0.0",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "execa": "0.5.1",
+            "execa": "0.7.0",
             "lcid": "1.0.0",
             "mem": "1.1.0"
           }
@@ -2856,21 +2948,20 @@
           }
         },
         "regenerator-runtime": {
-          "version": "0.10.5",
+          "version": "0.11.0",
           "bundled": true,
           "dev": true
         },
         "regex-cache": {
-          "version": "0.4.3",
+          "version": "0.4.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-equal-shallow": "0.1.3",
-            "is-primitive": "2.0.0"
+            "is-equal-shallow": "0.1.3"
           }
         },
         "remove-trailing-separator": {
-          "version": "1.0.2",
+          "version": "1.1.0",
           "bundled": true,
           "dev": true
         },
@@ -2925,12 +3016,25 @@
           }
         },
         "semver": {
-          "version": "5.3.0",
+          "version": "5.4.1",
           "bundled": true,
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "shebang-regex": "1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
@@ -2945,7 +3049,7 @@
           "dev": true
         },
         "source-map": {
-          "version": "0.5.6",
+          "version": "0.5.7",
           "bundled": true,
           "dev": true
         },
@@ -2959,7 +3063,7 @@
             "os-homedir": "1.0.2",
             "rimraf": "2.6.1",
             "signal-exit": "3.0.2",
-            "which": "1.2.14"
+            "which": "1.3.0"
           }
         },
         "spdx-correct": {
@@ -2981,7 +3085,7 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.1.0",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -3063,7 +3167,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "0.5.6",
+            "source-map": "0.5.7",
             "uglify-to-browserify": "1.0.2",
             "yargs": "3.10.0"
           },
@@ -3098,7 +3202,7 @@
           }
         },
         "which": {
-          "version": "1.2.14",
+          "version": "1.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -3176,12 +3280,12 @@
             "cliui": "3.2.0",
             "decamelize": "1.2.0",
             "get-caller-file": "1.0.2",
-            "os-locale": "2.0.0",
+            "os-locale": "2.1.0",
             "read-pkg-up": "2.0.0",
             "require-directory": "2.1.1",
             "require-main-filename": "1.0.1",
             "set-blocking": "2.0.0",
-            "string-width": "2.1.0",
+            "string-width": "2.1.1",
             "which-module": "2.0.0",
             "y18n": "3.2.1",
             "yargs-parser": "7.0.0"
@@ -3437,9 +3541,9 @@
       }
     },
     "pluralize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
-      "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
     },
     "prelude-ls": {
@@ -3550,13 +3654,13 @@
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.16",
+        "mime-types": "2.1.17",
         "oauth-sign": "0.8.2",
         "performance-now": "0.2.0",
         "qs": "6.4.0",
         "safe-buffer": "5.1.1",
         "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
+        "tough-cookie": "2.3.3",
         "tunnel-agent": "0.6.0",
         "uuid": "3.1.0"
       }
@@ -3597,9 +3701,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -3832,9 +3936,9 @@
       "dev": true
     },
     "tmp": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
-      "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
@@ -3849,9 +3953,9 @@
       }
     },
     "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "dev": true,
       "requires": {
         "punycode": "1.4.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Framework for easily creating and exposing APIs as methods",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Framework for easily creating and exposing APIs as methods",
   "main": "lib/index.js",
   "scripts": {

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -1,9 +1,14 @@
 const expect = require('chai').expect;
 const handler = require('../lib/handler');
 
+const mockLogger = {
+  info: () => {},
+};
+
 function execHandler(handle, args) {
   const mockCtx = {
     swatchCtx: {
+      logger: mockLogger,
       testVal: 100,
     },
   };


### PR DESCRIPTION
Update swatch so that we log at `info` level the raw request params before validation/parsing, and the final list of arguments before calling the client handler. Combined with https://github.com/builtforme/swatchjs-koa/pull/27, this should allow the client to provide their own logger instance to swatch, including a unique request-wide correlationId, which will log info from inside swatch from start to finish