### PR TITLE
Update docs to correct middleware.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ const model = swatch({
                 default: 'New User',
             },
         ],
-        middleware: [middlewareFn],
+        metadata: {
+            middleware: [middlewareFn],            
+        },
     },
 });
 ```
@@ -174,7 +176,7 @@ The following properties can be set:
 |:---                   |:---       |:---
 |`handler`              | Yes       | The API handler. Must be a function.
 |`args`                 | No        | Function arguments. Must be an array. See below for more information.
-|`middleware`           | No        | An array of functions to run as middleware. Accepts request context and callback function as params. Throw on error to abort request handler.
+|`metadata`             | No        | An object with additional information about the handler (see below).
 
 If the `args` array is present, it must match the function in arity (i.e., the
 number of arguments declared in the function must match the number of elements
@@ -193,6 +195,14 @@ If an element is an object, then the following properties are valid:
 
 If an element is a string "argName", then it is considered equivalent to the
 object `{ name: "argName" }`.
+
+If the `metadata` object is present, the following sub-properties can be set:
+
+| Property    | Required  | Description
+|:---         |:---       |:---
+|`noAuth`     | No        | A boolean that indicates whether the authAdapter (if any is defined by [swatchKoa](../swatchjs-koa) or [swatchExpress](../swatchjs-express) options) should be skipped for this particular method handler. Defaults to `false`.
+|`middleware` | No        | An array of functions to run as middleware. Accepts request context and callback function as params. Throw on error to abort request handler.
+
 
 ## Runtime errors
 
@@ -241,6 +251,13 @@ Each object will contain the following properties:
 |:---                   |:---                                                                       |
 |`name`                 | The name of the method. This is the same as the key in the API object.    |
 |`handle`               | A function used to execute the method handler. See [The `handle` function](#the-handle-function) below.   |
+|`metadata`             | An object with additional data about the method handler. |
+
+The `metadata` object will contain the following properties:
+
+| Property              | Description                                                               |
+|:---                   |:---                                                                       |
+|`noAuth`               | A boolean that describes whether `noAuth` was set on the method handler.  |
 |`middleware`           | An array of functions to execute as middleware before the method handler. |
 
 ### The `handle` function

--- a/docs/index.html
+++ b/docs/index.html
@@ -324,10 +324,9 @@ const model = swatch({
                                         <td>Function arguments. Must be an array. See below for more information.</td>
                                     </tr>
                                     <tr>
-                                        <td><code>middleware</code></td>
+                                        <td><code>metadata</code></td>
                                         <td>No</td>
-                                        <td>An array of functions to run as middleware. Accepts request context and callback
-                                            function as params. Throw on error to abort request handler.</td>
+                                        <td>An object with additional information about the handler (see below).</td>
                                     </tr>
                                 </tbody>
                             </table>
@@ -377,6 +376,29 @@ const model = swatch({
                             </table>
                             <p>If an element is a string "argName", then it is considered equivalent to the object <code>{ name: "argName" }</code>.</p>
 
+                            <p>If the <code>metadata</code> object is present, the following sub-properties can be set:</p>
+                            <table class="uk-table uk-table-striped">
+                                <thead class="thead-default">
+                                    <tr>
+                                        <th>Property</th>
+                                        <th>Required?</th>
+                                        <th>Description</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td><code>noAuth</code></td>
+                                        <td>No</td>
+                                        <td>A boolean that indicates whether the authAdapter (if any is defined by swatchKoa or swatchExpress options) should be skipped for this particular method handler. Defaults to <code>false</code>.</td>
+                                    </tr>
+                                    <tr>
+                                        <td><code>middleware</code></td>
+                                        <td>No</td>
+                                        <td>An array of functions to run as middleware. Accepts request context and callback
+                                            function as params. Throw on error to abort request handler.</td>
+                                    </tr>
+                                </tbody>
+                            </table>
 
                             <br>
                         </div>


### PR DESCRIPTION
The middleware array property is a child of a handler's `metadata`  object, not a top-level property.  Updated the docs to reflect this.  Also added description of `metadata.noAuth` option.