### PR TITLE
Improved Error Handling in Method Schema

### DIFF
--- a/lib/handler.js
+++ b/lib/handler.js
@@ -26,6 +26,7 @@ function getSchemaArgsMetadata(methodSchema) {
   try {
     functionArgs = fnArgs(methodSchema.handler);
   } catch (err) {
+    // eslint-disable-next-line no-console 
     console.error('Error processing method schema handler ', methodSchema);
     throw new Error(err);
   }

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -22,8 +22,13 @@ function safeLog(ctx, message) {
 
 function getSchemaArgsMetadata(methodSchema) {
   // Get string names of arguments defined in the handler function
-  const functionArgs = fnArgs(methodSchema.handler);
-
+  let functionArgs;
+  try {
+    functionArgs = fnArgs(methodSchema.handler);
+  } catch (err) {
+    console.error('Error processing method schema handler ', methodSchema);
+    throw new Error(err);
+  }
   // Check whether arguments were also defined in the method schema
   //  If so, first validate that schema and function have same arity
   if (methodSchema.args !== undefined) {

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -26,7 +26,7 @@ function getSchemaArgsMetadata(methodSchema) {
   try {
     functionArgs = fnArgs(methodSchema.handler);
   } catch (err) {
-    // eslint-disable-next-line no-console 
+    // eslint-disable-next-line no-console
     console.error('Error processing method schema handler ', methodSchema);
     throw new Error(err);
   }


### PR DESCRIPTION
Prior to this PR, if there was a problem with the handler method, you'd get a generic error that made it very difficult to figure out which handler had the problem:

```
file:///.../node_modules/function-arguments/index.js:1
SyntaxError: Identifier 'token' has already been declared
    at functionArguments (file:///.../node_modules/function-arguments/index.js:37:10)
    at getSchemaArgsMetadata (file:///.../node_modules/swatchjs/lib/handler.js:25:24)
    at getMatchFn (file:///.../node_modules/swatchjs/lib/handler.js:81:24)
    at handler (file:///.../node_modules/swatchjs/lib/handler.js:139:17)
    at prepare (file:///.../node_modules/swatchjs/lib/loader.js:10:27)
    at Array.map (<anonymous>)
    at load (file:///.../node_modules/swatchjs/lib/loader.js:25:37)
    at file:///.../src/routes/index.mjs:27:11
    at Generator.next (<anonymous>)

```

With this PR at least you get a little more to help troubleshoot:
```
Error processing method schema handler  { args:
   [ { name: 'param1', optional: false },
     { name: 'param2', optional: false } ],
  handler: [AsyncFunction: getHandler],
  metadata: { middleware: [ [AsyncFunction: requireAuthentication] ] } }
file:///.../node_modules/function-arguments/index.js:1
SyntaxError: Identifier 'token' has already been declared
    at functionArguments (file:///.../node_modules/function-arguments/index.js:37:10)
    at getSchemaArgsMetadata (file:///.../node_modules/swatchjs/lib/handler.js:25:24)
    at getMatchFn (file:///.../node_modules/swatchjs/lib/handler.js:81:24)
    at handler (file:///.../node_modules/swatchjs/lib/handler.js:139:17)
    at prepare (file:///.../node_modules/swatchjs/lib/loader.js:10:27)
    at Array.map (<anonymous>)
    at load (file:///.../node_modules/swatchjs/lib/loader.js:25:37)
    at file:///.../src/routes/index.mjs:27:11
    at Generator.next (<anonymous>)
```