### PR TITLE
feature: add flag to configure log level to trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ The following errors will be generated during runtime (when invoking the handler
 |`missing_arg`      | One or more of the required arguments were not provided.                  |
 
 
+## Logging
+
+By default if there is a logger on the context with name swatchCtx.logger it will be used to log the parameters and methods that each handler has been invoked with. If you would like to change the log level set a variable `swatchLogLevel` to `'trace'` on the `swatchCtx` object in your context.
+
 ## Exposing the API
 
 The API model created by invoking the `swatch` function can be passed to any

--- a/lib/handler.js
+++ b/lib/handler.js
@@ -15,7 +15,9 @@ function normalize(method) {
 function safeLog(ctx, message) {
   // Helper function to log validation and request info
   //  Checks for an available swatch logger before logging
-  if (ctx.swatchCtx.logger) {
+  if (ctx.swatchCtx.swatchLogLevel === 'trace') {
+    ctx.swatchCtx.logger.trace(message);
+  } else if (ctx.swatchCtx.logger) {
     ctx.swatchCtx.logger.info(message);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "Framework for easily creating and exposing APIs as methods",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs",
-  "version": "3.1.8",
+  "version": "3.2.0",
   "description": "Framework for easily creating and exposing APIs as methods",
   "main": "lib/index.js",
   "scripts": {

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -3,12 +3,14 @@ const handler = require('../lib/handler');
 
 const mockLogger = {
   info: () => {},
+  trace: () => {},
 };
 
 function execHandler(handle, args) {
   const mockCtx = {
     swatchCtx: {
       logger: mockLogger,
+      swatchLogLevel: 'trace',
       testVal: 100,
     },
   };
@@ -421,6 +423,29 @@ describe('handler', () => {
       };
       const handle = handler(method);
       expect(execHandler(handle, { a: '25', b: '50' })).to.equal(175);
+    });
+    it('should respect the swatchLogLevel parameter on swatchCtx', () => {
+      const method = {
+        handler: a => (a),
+        args: [
+          {
+            name: 'a',
+            parse: Number,
+          },
+        ],
+      };
+      const execHandlerWithLogLevel = (handle, args) => {
+        const mockCtx = {
+          swatchCtx: {
+            logger: mockLogger,
+            swatchLogLevel: 'trace',
+          },
+        };
+        handle.validate(mockCtx, args);
+        return handle.handle(mockCtx);
+      };
+      const handle = handler(method);
+      expect(execHandlerWithLogLevel(handle, { a: '25' })).to.equal(25);
     });
   });
 


### PR DESCRIPTION
**Introduction**
We are using swatchjs as part of one of our services. We have recently had issues with the number of logs we are creating. We have duplicates of data from the swatchjs library. We would like to change the log level of these messages so that we can configure globally when we see them.

**Changes:**
- Add parameter `swatchLogLevel` to Koa context `swatchCtx` object
